### PR TITLE
add --doi to start colomoto-docker with an image mirrored on Zenodo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,8 @@ setup(name="colomoto-docker",
         "console_scripts": [
             "colomoto-docker = colomoto_docker:main"
         ]
-    }
+    },
+    install_requires=[
+        "donodo"
+    ]
 )


### PR DESCRIPTION
Hi,

This option uses Donodo to pull an image from Zenodo. Before downloading the image, it checks if the image already exists locally. The test is achieved thanks to additional information introduced in the record during the deposition of the image (see pull-request pauleve/donodo#3). 
